### PR TITLE
Add Nso.isis_interfaces and use it in interfaces verification

### DIFF
--- a/fimutil/netam/arm.py
+++ b/fimutil/netam/arm.py
@@ -39,10 +39,16 @@ class NetworkARM:
         for dev in devs:
             dev_name = dev['name']
             ifaces = self.nso.interfaces(dev_name)
+            isis_ifaces = self.nso.isis_interfaces(dev_name)
             if ifaces:
                 for iface in list(ifaces):
+                    # skip if not an isis l2 p2p interfaces
+                    is_isis_iface = False
+                    for isis_iface in isis_ifaces:
+                        if iface['name'] == isis_iface['name']:
+                            is_isis_iface = True
                     # only keep interfaces in up status and of "*GigE0/1/2*" pattern
-                    if iface['admin-status'] == 'up' and re.search('GigE\d/\d/\d', iface['name']):
+                    if is_isis_iface and iface['admin-status'] == 'up' and re.search('GigE\d/\d/\d', iface['name']):
                         # get rid of 'statistics' attributes
                         iface.pop('statistics', None)
                         continue

--- a/fimutil/netam/nso.py
+++ b/fimutil/netam/nso.py
@@ -53,6 +53,24 @@ class NsoClient:
             # raise NetAmNsoError(f"GET: {self.nso_url}/{ep}: 'ietf-interfaces:interface' unfound in response")
         return ret_json['ietf-interfaces:interface']
 
+    def isis_interfaces(self, device_name) -> list:
+        # base = f"tailf-ncs:devices/device={device_name}/live-status/ietf-interfaces:interfaces-state/interface"
+        # params = "fields=name;admin-status;phys-address;speed;ietf-ip:ipv4;ietf-ip:ipv6"
+        # ep = f"{base}?{params}"
+        ep = f"tailf-ncs:devices/device={device_name}/config/tailf-ned-cisco-ios-xr:router/isis/tag"
+        ret_json = self._get(ep)
+        if 'tailf-ned-cisco-ios-xr:tag' not in ret_json:
+            return None
+        tags = ret_json['tailf-ned-cisco-ios-xr:tag']
+        if type(tags) is not list or len(tags) < 1:
+            return None
+            # raise NetAmNsoError(f"GET: {self.nso_url}/{ep}: 'ietf-interfaces:interface' unfound in response")
+        ifaces = tags[0]['interface']
+        for iface in list(ifaces):
+            if 'circuit-type' not in iface or iface['circuit-type'] != 'level-2-only' or 'point-to-point' not in iface:
+                ifaces.remove(iface)
+        return ifaces
+
     def get_config(self, config_file):
         if not config_file:
             config_file = os.getenv('HOME') + '/.netam.conf'

--- a/test/netam_test.py
+++ b/test/netam_test.py
@@ -13,6 +13,10 @@ class NetAmTest(unittest.TestCase):
     def testNsoClient(self):
         nso = NsoClient()
         devs = nso.devices()
+        for dev in devs:
+            dev_name = dev['name']
+            ifaces = nso.isis_interfaces(dev_name)
+            l = len(ifaces)
 
     def testSrPceClient(self):
         sr_pce = SrPceClient()


### PR DESCRIPTION
Network ARM topology will only include interfaces that are (1) in admin "up" status and (2) defined as l2 ptp interface under isis .

This is default and before using the SR-PCE based ISIS adjacency option. 

The last merged network-production model was scanned with this code.