### PR TITLE
73.ptp.config.override

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The general format example of the file is as follows (SITE1, SITE2 are all-caps 
       "URL": <URL of SITE2's dp switch in Ralph>,
       "Site": "SITE2"
     },
+    "ptp": true,
     "storage": {
       "Disk": "500TB"
     },

--- a/fimutil/__init__.py
+++ b/fimutil/__init__.py
@@ -3,5 +3,5 @@
 This is a package of Information Model utilitied for FABRIC
 for scanning different types of sites
 """
-__VERSION__ = "1.5.2"
+__VERSION__ = "1.5.3"
 __version__ = __VERSION__


### PR DESCRIPTION
Added support for overriding PTP site setting via static config. Addresses #73 
This version is in PyPi as 1.5.3