### PR TITLE
Extra connected ports configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,15 @@ The general format example of the file is as follows (SITE1, SITE2 are all-caps 
       }
     },
     "mac_offset": "f2:ab"
+    "connected_ports": [ "HundredGigE0/0/0/15" ]
   }
 }
 ```
 `mac_offset` intended to be used with OpenStack sites to aid unique MAC generation for vNICs. Note
 that the first octet of mac_offset must be [even](https://github.com/openstack/neutron-lib/blob/cf494c8be10b36daf238fa12cf7c615656e6640d/neutron_lib/api/validators/__init__.py#L40).
+
+`connected_ports` are only effective for generating JSON files (do not affect ARMs) which are then used to put other ports
+(not include uplinks and facility ports) into admin DOWN state.
 
 ### scan_net.py
 

--- a/fimutil/__init__.py
+++ b/fimutil/__init__.py
@@ -3,5 +3,5 @@
 This is a package of Information Model utilitied for FABRIC
 for scanning different types of sites
 """
-__VERSION__ = "1.5.3"
+__VERSION__ = "1.5.4"
 __version__ = __VERSION__

--- a/fimutil/ralph/site.py
+++ b/fimutil/ralph/site.py
@@ -137,6 +137,12 @@ class Site:
         dp_ports = list()
         for w in self.workers:
             dp_ports.extend(w.get_dp_ports())
+        # see if any extra ports are mentioned in the config file
+        if self.config and self.config.get(self.name) and self.config.get(self.name).get('connected_ports'):
+            dp_ports.extend(self.config.get(self.name).get('connected_ports'))
+        # uniquify and sort
+        dp_ports = list(set(dp_ports))
+        dp_ports.sort()
         ret["DataPlane"]["Connected_ports"] = dp_ports
         n = list()
         for w in self.workers:

--- a/fimutil/utilities/scan_site.py
+++ b/fimutil/utilities/scan_site.py
@@ -46,7 +46,7 @@ def main():
                         help="This is a lightweight site supporting only OpenStack virtual NICs")
     parser.add_argument("-c", "--config", action="store", default=".scan-config.json",
                         help="JSON-formatted additional configuration file, "
-                             "including e.g. odd site-dataplane switch mapping")
+                             "including e.g. odd site-dataplane switch mapping. Defaults to .scan-config.json")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Added ability to specify connected ports in a site via a static .scan-config.json file. Needed to support sites like NCSA which have EDC/ODC servers plugged in. Latest .scan-config.json is checked into fabric-testbed/aggregate-ads 

Latest version of utilities `1.5.4` is in PyPi. 