### PR TITLE
add --skip_device option for scan_net

### DIFF
--- a/fimutil/netam/arm.py
+++ b/fimutil/netam/arm.py
@@ -52,7 +52,7 @@ class NetworkARM:
             isis_ifaces = self.nso.isis_interfaces(dev_name)
             if ifaces:
                 if isis_ifaces is None:
-                    raise NetAmArmError(f"Device '{dev_name}' has no active isis interface")
+                    raise NetAmArmError(f"Device '{dev_name}' has no active isis interface - fix that or consider '--skip-device device-name'")
                 for iface in list(ifaces):
                     # skip if not an isis l2 p2p interfaces
                     is_isis_iface = False
@@ -111,6 +111,8 @@ class NetworkARM:
         regexVlanPort = re.compile(r'\/\d+/\d+\/\d+\.\d+$') # ignore BE (like Bundle-Ether101.3000) for site ports
         # add site nodes
         for node in nodes:
+            if 'interfaces' not in node:
+                continue
             # add switch node
             node_name = node['name']
             # TODO: get model name from NSO

--- a/fimutil/utilities/scan_net.py
+++ b/fimutil/utilities/scan_net.py
@@ -20,9 +20,10 @@ def main():
                         help="Turn on debugging")
     parser.add_argument("-m", "--model", action="store",
                         help="Produce an ARM model of a site and save into indicated file")
-
     parser.add_argument("--isis-link-validation", action="store_true",
                         help="Only include validated links in the IS-IS topology")
+    parser.add_argument("--skip-device", action="store",
+                        help="Skip the devices listed (comma separated)")
 
     args = parser.parse_args()
 
@@ -35,7 +36,7 @@ def main():
         print('You must specify the name of the file to save the model into', file=sys.stderr)
         sys.exit(-1)
 
-    arm = NetworkARM(config_file=args.config, isis_link_validation=args.isis_link_validation)
+    arm = NetworkARM(config_file=args.config, isis_link_validation=args.isis_link_validation, skip_device=args.skip_device)
 
     logging.info('Querying NSO')
     if args.isis_link_validation:


### PR DESCRIPTION
When some device has no isis interface configured and we still want to scan, this patch will firstly report an error. Then we can use the --skip-device option to skip one or multiple devices. 

Devices without p2p links configured in NetworkController inventory will be skipped as well.